### PR TITLE
update css & searchbox text

### DIFF
--- a/sphinx_typlog_theme/searchbox.html
+++ b/sphinx_typlog_theme/searchbox.html
@@ -2,7 +2,7 @@
 <div id="searchbox">
   <form class="search" action="{{ pathto('search') }}" method="get">
     <div class="input-group">
-      <input type="text" name="q" placeholder="{{ _('Enter search terms or a module, class or function name.') }}" />
+      <input type="text" name="q" placeholder="{{ _('Search') }}" />
       <button type="submit">{{ _('Go') }}</button>
     </div>
     <input type="hidden" name="check_keywords" value="yes" />

--- a/sphinx_typlog_theme/static/typlog.css
+++ b/sphinx_typlog_theme/static/typlog.css
@@ -539,6 +539,11 @@ a {
     clear: both
 }
 
+.line-block {
+    display: block;
+    margin-bottom: 1em;
+}
+
 .sidebar {
     position: fixed;
     z-index: 10;

--- a/sphinx_typlog_theme/static/typlog.css
+++ b/sphinx_typlog_theme/static/typlog.css
@@ -533,8 +533,7 @@ a {
 }
 
 .guide-links:after,
-.inner:after,
-.section:after {
+.inner:after {
     display: table;
     content: '';
     clear: both

--- a/sphinx_typlog_theme/static/typlog.css
+++ b/sphinx_typlog_theme/static/typlog.css
@@ -1,1 +1,1694 @@
-html{font-family:sans-serif;line-height:1.15;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}article,aside,footer,header,nav,section{display:block}h1{font-size:2em;margin:.67em 0}figcaption,figure,main{display:block}figure{margin:1em 40px}hr{box-sizing:content-box;height:0;overflow:visible}pre{font-family:monospace,monospace;font-size:1em}a{background-color:transparent;-webkit-text-decoration-skip:objects}a:active,a:hover{outline-width:0}abbr[title]{border-bottom:none;text-decoration:underline;text-decoration:underline dotted}b,strong{font-weight:inherit}b,strong{font-weight:bolder}code,kbd,samp{font-family:monospace,monospace;font-size:1em}dfn{font-style:italic}mark{background-color:#ff0;color:#000}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}audio,video{display:inline-block}audio:not([controls]){display:none;height:0}img{border-style:none}svg:not(:root){overflow:hidden}button,input,optgroup,select,textarea{font-family:sans-serif;font-size:100%;line-height:1.15;margin:0}button,input{overflow:visible}button,select{text-transform:none}[type=reset],[type=submit],button,html [type=button]{-webkit-appearance:button}[type=button]::-moz-focus-inner,[type=reset]::-moz-focus-inner,[type=submit]::-moz-focus-inner,button::-moz-focus-inner{border-style:none;padding:0}[type=button]:-moz-focusring,[type=reset]:-moz-focusring,[type=submit]:-moz-focusring,button:-moz-focusring{outline:1px dotted ButtonText}fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}legend{box-sizing:border-box;color:inherit;display:table;max-width:100%;padding:0;white-space:normal}progress{display:inline-block;vertical-align:baseline}textarea{overflow:auto}[type=checkbox],[type=radio]{box-sizing:border-box;padding:0}[type=number]::-webkit-inner-spin-button,[type=number]::-webkit-outer-spin-button{height:auto}[type=search]{-webkit-appearance:textfield;outline-offset:-2px}[type=search]::-webkit-search-cancel-button,[type=search]::-webkit-search-decoration{-webkit-appearance:none}::-webkit-file-upload-button{-webkit-appearance:button;font:inherit}details,menu{display:block}summary{display:list-item}canvas{display:inline-block}template{display:none}[hidden]{display:none}.yue h1,.yue h2,.yue h3,.yue h4,.yue h5,.yue h6{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:-apple-system,BlinkMacSystemFont,"Helvetica Neue","PingFang SC","Hiragino Sans GB","Droid Sans Fallback","Microsoft YaHei",sans-serif;color:rgba(0,0,0,.98)}.yue h1{font-weight:700;font-size:1.8em;margin:.8em 0}.yue h2{font-weight:700;font-size:1.42em;margin:1.42em 0 .4em}.yue h3{font-size:1.17em;margin:1.62em 0 .4em}.yue h4,.yue h5,.yue h6{font-size:1em;margin:1.6em 0 .6em}.yue h6{font-weight:500}.yue p{margin-top:0;margin-bottom:1.02em;hyphens:auto}.yue a{color:rgba(0,0,0,.98);word-wrap:break-word;text-decoration:none;border-bottom:1px solid rgba(0,0,0,.26)}.yue a:hover{color:rgba(0,0,0,.6);border-color:rgba(0,0,0,.6)}.yue h1 a,.yue h2 a,.yue h3 a{text-decoration:none}.yue b,.yue strong{-webkit-font-smoothing:antialiased;font-weight:700;color:rgba(0,0,0,.9)}.yue em,.yue i{font-style:italic;color:rgba(0,0,0,.9)}.yue img,.yue video{max-width:100%;height:auto;margin:.2em 0}.yue a img{border:none;vertical-align:middle}.yue figure{position:relative;clear:both;outline:0;margin:10px 0 30px;padding:0;min-height:100px}.yue figure img{display:block;max-width:100%;margin:0 auto;box-sizing:border-box}.yue figcaption{width:100%;text-align:center;left:0;margin-top:10px;font-weight:400;font-size:14px;color:rgba(0,0,0,.42)}.yue figcaption a{text-decoration:none;color:rgba(0,0,0,.42)}.yue hr{display:block;width:90%;max-width:100px;border:0;border-top:1px solid rgba(0,0,0,.04);margin:1.42em auto 1.84em}.yue blockquote{position:relative;padding:10px 10px 10px 38px;margin:1em 0;color:rgba(0,0,0,.68)}.yue blockquote:before{position:absolute;top:6px;left:6px;content:'“';font:bold 48px/1 Georgia,serif;color:rgba(0,0,0,.1)}.yue blockquote a{color:rgba(0,0,0,.68)}.yue ol,.yue ul{margin:0 0 24px 6px;padding-left:16px}.yue ul{list-style-type:square}.yue ol{list-style-type:decimal}.yue li{margin-bottom:.2em}.yue li ol,.yue li ul{margin-top:0;margin-bottom:0}.yue li ul{list-style-type:disc}.yue li ul ul{list-style-type:circle}.yue li p{margin:.4em 0 .6em}.yue code,.yue tt{background-color:rgba(220,220,220,.2);color:#f55826;font-size:.96em;padding:1px 4px;border-radius:2px;font-family:Consolas,Menlo,Monaco,"Courier New",monospace;word-wrap:break-word}.yue pre{margin:1.4em 0;padding:16px 16px 16px 18px;border:none;border-left:3px solid rgba(0,0,0,.08);overflow:auto;line-height:1.5;font-size:.98em;font-family:Consolas,"Roboto Mono",Menlo,Monaco,"Courier New",monospace;color:rgba(0,0,0,.68);background-color:rgba(0,0,0,.02)}.yue pre code,.yue pre tt{color:rgba(0,0,0,.68);border:none;background:0 0;padding:0}.yue table{width:100%;max-width:100%;border-collapse:collapse;border-spacing:0;margin-bottom:1.5em;font-size:.96em;box-sizing:border-box}.yue iframe{display:block;max-width:100%;margin-bottom:30px}.yue figure iframe{margin:auto}.yue table pre{margin:0;padding:0;border:none;background:0 0}[lang^=en] .yue h1{font-weight:900}.yue table[border] td,.yue table[border] th{text-align:left;padding:6px 8px 6px 10px;border:1px solid #ddd}.yue table[border] td{vertical-align:top}.yue table[border] tr:nth-child(even){background-color:rgba(0,0,0,.01)}body{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font:400 16px/1.42 Roboto,"Helvetica Neue",Helvetica,sans-serif;color:rgba(0,0,0,.68)}img{max-width:100%;vertical-align:middle}h1,h2,h3,strong{color:rgba(0,0,0,.9)}a{color:rgba(0,0,0,.86);text-decoration:none}.guide-links:after,.inner:after,.section:after{display:table;content:'';clear:both}.sidebar{position:fixed;z-index:10;top:0;left:0;bottom:0;background:#f9f9f9;border-right:1px solid #efefef;overflow-x:hidden;overflow-y:auto;-webkit-overflow-scrolling:touch;-ms-overflow-style:none}.sidebar .inner{width:260px;padding:20px 40px 40px}.sidebar a{text-decoration:none;color:#343;border-bottom:1px solid transparent}.sidebar a:hover{border-color:rgba(0,0,0,.1)}.sidebar h3{margin:1em 0 .2em;letter-spacing:-.06em;color:#252b31;font-family:-apple-system,BlinkMacSystemFont,"Helvetica Neue","PingFang SC","Hiragino Sans GB","Droid Sans Fallback","Microsoft YaHei",sans-serif}.sidebar h1>a,.sidebar h2>a,.sidebar h3>a{border-bottom-width:0}.sidebar ul{list-style-type:none;margin:0;padding:0}.sidebar li{margin-top:4px}.sidebar li>ul{padding-left:1em}.sidebar li>a{text-decoration:none;border-bottom-width:2px}.mobile-close{display:none;position:absolute;right:10px;top:10px}.content{margin-left:340px;padding:20px 80px 0;overflow:hidden}.content>footer{font-size:.86em;color:#999;padding:20px 0}.content>footer:before{display:block;margin-bottom:1em;content:'';width:100px;border-top:4px solid rgba(0,0,0,.1)}.content>footer a{color:#666;text-decoration:underline}.head{display:none}.globaltoc{margin:20px 0}.globaltoc>p.caption{display:none}.guide-links{margin-top:1em;font-family:"Source Sans Pro","Helvetica Neue",Arial,sans-serif}.guide-links a{border:0;font-weight:500}@media (max-width:960px){.sidebar{transform:translate3d(-341px,0,0);transition:transform .2s ease}.expand .sidebar{transform:translate3d(0,0,0);max-width:100%}.expand .mobile-close{display:block}.content{padding:64px 20px 0;max-width:840px;margin:0 auto;box-sizing:border-box}.head{display:block;position:fixed;width:100%;padding:1em 20px;box-sizing:border-box;text-align:center;border-bottom:1px solid #efefef;background:#fff;z-index:9}.head_menu{position:absolute;top:1em;left:2em}.head_menu svg,.mobile-close svg{width:30px;fill:#ccc}.head_logo{font-weight:600}.head_logo img{vertical-align:middle;margin-right:6px;width:30px;height:30px}}.rst-other-versions input[name="q"],body[data-page=search] input[name="q"]{border:2px solid rgba(0,0,0,.86);padding:0 10px;line-height:38px;outline:0;box-sizing:border-box}body[data-page=search] input[type=submit]{line-height:42px}#typlog-footnote-mask{display:none;-webkit-tap-highlight-color:transparent}#typlog-footnote-mask.Active{display:block;position:fixed;top:0;left:0;width:100%;height:100%;z-index:9}#typlog-footnote-content,#typlog-footnote-content a[href^="#fnref"]{display:none}#typlog-footnote-content.Active{display:block;font-size:.86em;color:rgba(0,0,0,.68);position:absolute;z-index:10;width:100%;max-width:560px;margin-top:20px;background:#fff;padding:20px;box-sizing:border-box;box-shadow:0 0 10px 1px rgba(0,0,0,.16)}@media (min-width:560px){#typlog-footnote-content.Active{border-radius:3px}}.highlight{color:#586e75}.highlight .hll{font-weight:700}.highlight .c{color:#93a1a1}.highlight .err{color:#586e75}.highlight .g{color:#586e75}.highlight .k{color:#859900}.highlight .l{color:#586e75}.highlight .n{color:#586e75}.highlight .o{color:#859900}.highlight .x{color:#cb4b16}.highlight .p{color:#586e75}.highlight .cm{color:#93a1a1}.highlight .cp{color:#859900}.highlight .c1{color:#93a1a1}.highlight .cs{color:#859900}.highlight .gd{color:#2aa198}.highlight .ge{color:#586e75;font-style:italic}.highlight .gr{color:#dc322f}.highlight .gh{color:#cb4b16}.highlight .gi{color:#859900}.highlight .go{color:#586e75}.highlight .gp{color:#586e75}.highlight .gs{color:#586e75;font-weight:700}.highlight .gu{color:#cb4b16}.highlight .gt{color:#586e75}.highlight .kc{color:#cb4b16}.highlight .kd{color:#268bd2}.highlight .kn{color:#859900}.highlight .kp{color:#859900}.highlight .kr{color:#268bd2}.highlight .kt{color:#dc322f}.highlight .ld{color:#586e75}.highlight .m{color:#2aa198}.highlight .s{color:#2aa198}.highlight .na{color:#586e75}.highlight .nb{color:#b58900}.highlight .nc{color:#268bd2}.highlight .no{color:#cb4b16}.highlight .nd{color:#268bd2}.highlight .ni{color:#cb4b16}.highlight .ne{color:#cb4b16}.highlight .nf{color:#268bd2}.highlight .nl{color:#586e75}.highlight .nn{color:#586e75}.highlight .nx{color:#586e75}.highlight .py{color:#586e75}.highlight .nt{color:#268bd2}.highlight .nv{color:#268bd2}.highlight .ow{color:#859900}.highlight .w{color:#586e75}.highlight .mf{color:#2aa198}.highlight .mh{color:#2aa198}.highlight .mi{color:#2aa198}.highlight .mo{color:#2aa198}.highlight .sb{color:#93a1a1}.highlight .sc{color:#2aa198}.highlight .sd{color:#586e75}.highlight .s2{color:#2aa198}.highlight .se{color:#cb4b16}.highlight .sh{color:#586e75}.highlight .si{color:#2aa198}.highlight .sx{color:#2aa198}.highlight .sr{color:#dc322f}.highlight .s1{color:#2aa198}.highlight .ss{color:#2aa198}.highlight .bp{color:#268bd2}.highlight .vc{color:#268bd2}.highlight .vg{color:#268bd2}.highlight .vi{color:#268bd2}.highlight .il{color:#2aa198}a.toc-backref{border:0}a.headerlink{margin-left:1px;color:rgba(0,0,0,.24);text-decoration:none;visibility:hidden;border-width:0}a.headerlink:hover{background-color:rgba(0,0,0,.02)}caption:hover>a.headerlink,div.code-block-caption:hover>a.headerlink,dt:hover>a.headerlink,h1:hover>a.headerlink,h2:hover>a.headerlink,h3:hover>a.headerlink,h4:hover>a.headerlink,h5:hover>a.headerlink,h6:hover>a.headerlink,p.caption:hover>a.headerlink{visibility:visible}a>.std-ref{font-weight:700}.contents{display:inline-block;padding:16px 40px 16px 0;background:#f9f9f9;min-width:240px;font-size:13px;font-weight:500;border-radius:5px}.contents .topic-title{color:rgba(0,0,0,.4);padding-left:16px;margin-bottom:10px;text-transform:uppercase}.contents li>ul,.contents li>ul ul,.contents ul{list-style-type:none}.contents ul{margin:0}.contents li{margin-top:4px}.contents a{border-bottom:0;color:rgba(0,0,0,.5)}.admonition{position:relative;padding:40px 24px 18px 24px;margin:2em 0;border-left:4px solid #ddd;background-color:#f8f8f8}.admonition:before{position:absolute;content:'#';top:14px;left:-12px;color:#fff;width:20px;height:20px;border-radius:100%;background-color:#ddd;text-align:center;font:normal bold 14px/20px "Helvetica Neue",Arial,sans-serif}.admonition.tip:before{content:'T';font-size:12px}.admonition>.admonition-title{position:absolute;margin:0;top:12px;left:24px;font-size:.8em;color:rgba(0,0,0,.4);text-transform:uppercase}.admonition>.last{margin-bottom:0}.admonition.attention,.admonition.note{border-color:#03a9f4;background-color:rgba(3,172,244,.08)}.admonition.attention:before,.admonition.note:before{background-color:#03a9f4}.admonition.attention:before{content:'!'}.admonition.attention>.admonition-title,.admonition.note>.admonition-title{font-weight:700;color:#03a9f4}.admonition.caution,.admonition.warning{border-color:#f7ba2a;background-color:rgba(247,186,42,.1)}.admonition.caution:before,.admonition.warning:before{content:'!';background-color:#f7ba2a}.admonition.caution>.admonition-title,.admonition.warning>.admonition-title{font-weight:700;color:#f1b52a}.admonition.danger,.admonition.error{border-color:#ff612f;background-color:rgba(255,92,47,.08)}.admonition.danger:before,.admonition.error:before{content:'!';background-color:#ff612f}.admonition.danger>.admonition-title,.admonition.error>.admonition-title{font-weight:700;color:#ff612f}.admonition.important{border-color:#b37feb;background-color:rgba(179,127,235,.1)}.admonition.important:before{background-color:#b37feb}.admonition.important>.admonition-title{font-weight:700;color:#b37feb}.admonition.hint{border-color:#36cfc9;background-color:rgba(8,151,156,.1)}.admonition.hint:before{background-color:#36cfc9}.admonition.hint>.admonition-title{font-weight:700;color:#36cfc9}.admonition.tip{border-color:#f759ab;background-color:rgba(247,89,171,.1)}.admonition.tip:before{background-color:#f759ab}.admonition.tip>.admonition-title{font-weight:700;color:#f759ab}.versionmodified{color:rgba(0,0,0,.86);font-weight:700}.deprecated,.versionadded,.versionchanged{position:relative;padding:8px 24px;margin:1em 0;border-left:4px solid transparent}.deprecated:before,.versionadded:before,.versionchanged:before{position:absolute;content:'!';top:8px;left:-12px;color:#fff;width:20px;height:20px;border-radius:100%;text-align:center;font:normal bold 14px/20px "Helvetica Neue",Arial,sans-serif}.versionadded{border-color:#49c784;background-color:rgba(73,199,132,.08)}.versionadded:before{content:'#';background-color:#49c784}.versionchanged{border-color:#f7ba2a;background-color:rgba(247,186,42,.08)}.versionchanged:before{background-color:#f7ba2a}.deprecated{border-color:#ff612f;background-color:rgba(255,92,47,.08)}.deprecated:before{background-color:#ff612f}.deprecated>p,.versionadded>p,.versionchanged>p{margin:0}.yue table.footnote{display:none}a.footnote-reference{display:inline-block;padding:0 4px;text-align:center;font-weight:700;font-size:8px;line-height:14px;border-bottom:0;background-color:rgba(0,0,0,.18);color:#fff;border-radius:3px;vertical-align:top;transition:all .1s ease}.body a.footnote-reference:hover{color:#fff;background-color:rgba(0,0,0,.8)}.yue table.citation{margin-bottom:10px}table.docutils td.label{width:1px;padding-right:.6em}.button{display:inline-block;padding:1.2em 2em;font-weight:700;letter-spacing:.25rem;text-transform:uppercase;text-decoration:none;color:#fff;background-color:rgba(0,0,0,.98);border:0;transition:background-color .1s}.input-group{display:flex;border:2px solid rgba(0,0,0,.86)}.input-group>input[type=text]{flex-grow:1;outline:0;border:0;padding:.6em 10px}.input-group>button,body[data-page=search] input[type=submit]{display:inline-block;padding:0 .8em;font-weight:700;text-transform:uppercase;text-decoration:none;color:#fff;background-color:rgba(0,0,0,.86);border:0;transition:background-color .1s;cursor:pointer;border-radius:0;outline:0}.highlighted{padding:1px 4px;opacity:.6;color:#fff;background-color:rgba(0,0,0,.68)}.highlight,.literal-block-wrapper{margin:1.4em 0}.highlight pre,.highlighttable .highlight,.literal-block-wrapper .highlight{margin:0}.code-block-caption{color:rgba(0,0,0,.3)}.highlighttable{background:rgba(0,0,0,.02)}.highlighttable .linenos{width:1px}.highlighttable .linenodiv{padding:10px 6px;background:rgba(0,0,0,.03);text-align:right}.highlighttable .linenodiv pre{color:rgba(0,0,0,.3)}.highlighttable .highlight{padding-left:10px}.hlist td{vertical-align:top}p.centered{text-align:center}.float-left{float:left}.float-right{float:right}.project_description{margin:1em 0;color:rgba(0,0,0,.6)}a.logo{display:block;font-size:1.2em;font-weight:900;letter-spacing:1px;text-decoration:none;margin-bottom:1em;border:0}.logo img{vertical-align:middle;margin-right:6px;width:40px;height:40px}.github_wrap{margin:1em 0}.github_wrap .github{display:inline-block;border:1px solid #d5d5d5;background-image:linear-gradient(to bottom,#fcfcfc 0,#eee 100%);padding:6px 14px;border-radius:5px}.github>span{display:inline-block;text-align:center;vertical-align:middle;line-height:1;font-size:14px;color:rgba(0,0,0,.5)}.github_icon{width:30px;height:30px;background-image:url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjQwcHgiIGhlaWdodD0iNDBweCIgdmlld0JveD0iMTIgMTIgNDAgNDAiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMTIgMTIgNDAgNDAiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwYXRoIGZpbGw9IiMzMzMzMzMiIGQ9Ik0zMiAxMy40Yy0xMC41IDAtMTkgOC41LTE5IDE5YzAgOC40IDUuNSAxNS41IDEzIDE4YzEgMC4yIDEuMy0wLjQgMS4zLTAuOWMwLTAuNSAwLTEuNyAwLTMuMiBjLTUuMyAxLjEtNi40LTIuNi02LjQtMi42QzIwIDQxLjYgMTguOCA0MSAxOC44IDQxYy0xLjctMS4yIDAuMS0xLjEgMC4xLTEuMWMxLjkgMC4xIDIuOSAyIDIuOSAyYzEuNyAyLjkgNC41IDIuMSA1LjUgMS42IGMwLjItMS4yIDAuNy0yLjEgMS4yLTIuNmMtNC4yLTAuNS04LjctMi4xLTguNy05LjRjMC0yLjEgMC43LTMuNyAyLTUuMWMtMC4yLTAuNS0wLjgtMi40IDAuMi01YzAgMCAxLjYtMC41IDUuMiAyIGMxLjUtMC40IDMuMS0wLjcgNC44LTAuN2MxLjYgMCAzLjMgMC4yIDQuNyAwLjdjMy42LTIuNCA1LjItMiA1LjItMmMxIDIuNiAwLjQgNC42IDAuMiA1YzEuMiAxLjMgMiAzIDIgNS4xYzAgNy4zLTQuNSA4LjktOC43IDkuNCBjMC43IDAuNiAxLjMgMS43IDEuMyAzLjVjMCAyLjYgMCA0LjYgMCA1LjJjMCAwLjUgMC40IDEuMSAxLjMgMC45YzcuNS0yLjYgMTMtOS43IDEzLTE4LjFDNTEgMjEuOSA0Mi41IDEzLjQgMzIgMTMuNHoiLz48L3N2Zz4=);background-size:100% 100%;background-repeat:no-repeat}.github span>strong{display:block;font-size:16px}.github_stars{position:relative;margin:0 20px 0 10px}.github_stars:after{content:'';display:block;border-right:1px solid rgba(0,0,0,.2);height:12px;position:absolute;right:-14px;top:10px}.sponsors{margin:15px 0}.sponsor{background:rgba(0,0,0,.05);padding:15px;margin:5px 0;border-radius:4px}.sponsor:after{content:'';display:table;clear:both}.sponsor img{width:48px;vertical-align:middle}.sponsor a.sponsor_image{float:left;border-bottom:none}.sponsor_text{overflow:hidden;padding-left:10px;vertical-align:middle;max-width:calc(100% - 60px)}.content .sponsor,.content .sponsor_text{display:inline-block}.content .sponsor img{width:auto;height:40px}.content a.sponsor_image{display:inline-block;float:none}.badge{display:inline-block;padding:3px 6px;min-width:3em;text-align:center;vertical-align:middle;background-color:#999;color:#fff;line-height:1;border-radius:2px;font-size:13px;opacity:.98;margin-right:4px;font-family:Consolas,Menlo,Monaco,"Courier New",monospace;user-select:none}.badge-one{font-size:12px;min-width:0;padding:4px 6px}.badge-todo,.badge-yellow{background-color:#f7ba2a}.badge-done,.badge-green{background-color:#49c784}.badge-blue,.badge-doing,.badge-plan{background-color:#03a9f4}.badge-red{background-color:#ff612f}code.descclassname{padding:0;background-color:transparent}code.descname{font-weight:700;padding:0;background-color:transparent}dd{margin:4px 0 10px 2em}dd>table.field-list .field-name{display:block;font-size:.86em;color:rgba(245,88,38,.8);padding:0;text-align:left;text-transform:uppercase}dd>table.field-list .field-body{display:block;padding:0 0 0 1em}.yue dd>p{margin-bottom:.86em}dl.class dt,dl.data dt,dl.exception dt,dl.function dt,dl.method dt{padding:5px;color:rgba(0,0,0,.4);border-top:2px solid rgba(245,88,38,.4);background:rgba(245,88,38,.05)}dl.class dt>em,dl.data dt>em,dl.exception dt>em,dl.function dt>em,dl.method dt>em{font-size:.98em;color:rgba(0,0,0,.68)}.injected .rst-versions.rst-badge{left:0;bottom:0;width:340px;max-width:100%;color:rgba(0,0,0,.68);background-color:#f7f7f7}.injected .rst-versions.rst-badge .rst-current-version{text-align:right;background-color:#eee}.injected .rst-versions.rst-badge .fa-book{float:left}.injected .rst-versions .rst-current-version .fa,.injected .rst-versions .rst-other-versions dd a{color:rgba(0,0,0,.68)}.injected .rst-versions .rst-other-versions hr{border-color:#ddd}@media (max-width:960px){.injected .rst-versions{transform:translate3d(-340px,0,0);transition:transform .2s ease}.expand .injected .rst-versions{transform:translate3d(0,0,0)}}
+html {
+    font-family: sans-serif;
+    line-height: 1.15;
+    -ms-text-size-adjust: 100%;
+    -webkit-text-size-adjust: 100%
+}
+
+body {
+    margin: 0
+}
+
+article,
+aside,
+footer,
+header,
+nav,
+section {
+    display: block
+}
+
+h1 {
+    font-size: 2em;
+    margin: .67em 0
+}
+
+figcaption,
+figure,
+main {
+    display: block
+}
+
+figure {
+    margin: 1em 40px
+}
+
+hr {
+    box-sizing: content-box;
+    height: 0;
+    overflow: visible
+}
+
+pre {
+    font-family: monospace, monospace;
+    font-size: 1em
+}
+
+a {
+    background-color: transparent;
+    -webkit-text-decoration-skip: objects
+}
+
+a:active,
+a:hover {
+    outline-width: 0
+}
+
+abbr[title] {
+    border-bottom: none;
+    text-decoration: underline;
+    text-decoration: underline dotted
+}
+
+b,
+strong {
+    font-weight: inherit
+}
+
+b,
+strong {
+    font-weight: bolder
+}
+
+code,
+kbd,
+samp {
+    font-family: monospace, monospace;
+    font-size: 1em
+}
+
+dfn {
+    font-style: italic
+}
+
+mark {
+    background-color: #ff0;
+    color: #000
+}
+
+small {
+    font-size: 80%
+}
+
+sub,
+sup {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline
+}
+
+sub {
+    bottom: -.25em
+}
+
+sup {
+    top: -.5em
+}
+
+audio,
+video {
+    display: inline-block
+}
+
+audio:not([controls]) {
+    display: none;
+    height: 0
+}
+
+img {
+    border-style: none
+}
+
+svg:not(:root) {
+    overflow: hidden
+}
+
+button,
+input,
+optgroup,
+select,
+textarea {
+    font-family: sans-serif;
+    font-size: 100%;
+    line-height: 1.15;
+    margin: 0
+}
+
+button,
+input {
+    overflow: visible
+}
+
+button,
+select {
+    text-transform: none
+}
+
+[type=reset],
+[type=submit],
+button,
+html [type=button] {
+    -webkit-appearance: button
+}
+
+[type=button]::-moz-focus-inner,
+[type=reset]::-moz-focus-inner,
+[type=submit]::-moz-focus-inner,
+button::-moz-focus-inner {
+    border-style: none;
+    padding: 0
+}
+
+[type=button]:-moz-focusring,
+[type=reset]:-moz-focusring,
+[type=submit]:-moz-focusring,
+button:-moz-focusring {
+    outline: 1px dotted ButtonText
+}
+
+fieldset {
+    border: 1px solid silver;
+    margin: 0 2px;
+    padding: .35em .625em .75em
+}
+
+legend {
+    box-sizing: border-box;
+    color: inherit;
+    display: table;
+    max-width: 100%;
+    padding: 0;
+    white-space: normal
+}
+
+progress {
+    display: inline-block;
+    vertical-align: baseline
+}
+
+textarea {
+    overflow: auto
+}
+
+[type=checkbox],
+[type=radio] {
+    box-sizing: border-box;
+    padding: 0
+}
+
+[type=number]::-webkit-inner-spin-button,
+[type=number]::-webkit-outer-spin-button {
+    height: auto
+}
+
+[type=search] {
+    -webkit-appearance: textfield;
+    outline-offset: -2px
+}
+
+[type=search]::-webkit-search-cancel-button,
+[type=search]::-webkit-search-decoration {
+    -webkit-appearance: none
+}
+
+::-webkit-file-upload-button {
+    -webkit-appearance: button;
+    font: inherit
+}
+
+details,
+menu {
+    display: block
+}
+
+summary {
+    display: list-item
+}
+
+canvas {
+    display: inline-block
+}
+
+template {
+    display: none
+}
+
+[hidden] {
+    display: none
+}
+
+.yue h1,
+.yue h2,
+.yue h3,
+.yue h4,
+.yue h5,
+.yue h6 {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei", sans-serif;
+    color: rgba(0, 0, 0, .98)
+}
+
+.yue h1 {
+    font-weight: 700;
+    font-size: 1.8em;
+    margin: .8em 0
+}
+
+.yue h2 {
+    font-weight: 700;
+    font-size: 1.42em;
+    margin: 1.42em 0 .4em
+}
+
+.yue h3 {
+    font-size: 1.17em;
+    margin: 1.62em 0 .4em
+}
+
+.yue h4,
+.yue h5,
+.yue h6 {
+    font-size: 1em;
+    margin: 1.6em 0 .6em
+}
+
+.yue h6 {
+    font-weight: 500
+}
+
+.yue p {
+    margin-top: 0;
+    margin-bottom: 1.02em;
+    hyphens: auto
+}
+
+.yue a {
+    color: rgba(0, 0, 0, .98);
+    word-wrap: break-word;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(0, 0, 0, .26)
+}
+
+.yue a:hover {
+    color: rgba(0, 0, 0, .6);
+    border-color: rgba(0, 0, 0, .6)
+}
+
+.yue h1 a,
+.yue h2 a,
+.yue h3 a {
+    text-decoration: none
+}
+
+.yue b,
+.yue strong {
+    -webkit-font-smoothing: antialiased;
+    font-weight: 700;
+    color: rgba(0, 0, 0, .9)
+}
+
+.yue em,
+.yue i {
+    font-style: italic;
+    color: rgba(0, 0, 0, .9)
+}
+
+.yue img,
+.yue video {
+    max-width: 100%;
+    height: auto;
+    margin: .2em 0
+}
+
+.yue a img {
+    border: none;
+    vertical-align: middle
+}
+
+.yue figure {
+    position: relative;
+    clear: both;
+    outline: 0;
+    margin: 10px 0 30px;
+    padding: 0;
+    min-height: 100px
+}
+
+.yue figure img {
+    display: block;
+    max-width: 100%;
+    margin: 0 auto;
+    box-sizing: border-box
+}
+
+.yue figcaption {
+    width: 100%;
+    text-align: center;
+    left: 0;
+    margin-top: 10px;
+    font-weight: 400;
+    font-size: 14px;
+    color: rgba(0, 0, 0, .42)
+}
+
+.yue figcaption a {
+    text-decoration: none;
+    color: rgba(0, 0, 0, .42)
+}
+
+.yue hr {
+    display: block;
+    width: 90%;
+    max-width: 100px;
+    border: 0;
+    border-top: 1px solid rgba(0, 0, 0, .04);
+    margin: 1.42em auto 1.84em
+}
+
+.yue blockquote {
+    position: relative;
+    padding: 10px 10px 10px 38px;
+    margin: 1em 0;
+    color: rgba(0, 0, 0, .68)
+}
+
+.yue blockquote:before {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    content: '“';
+    font: bold 48px/1 Georgia, serif;
+    color: rgba(0, 0, 0, .1)
+}
+
+.yue blockquote a {
+    color: rgba(0, 0, 0, .68)
+}
+
+.yue ol,
+.yue ul {
+    margin: 0 0 24px 6px;
+    padding-left: 16px
+}
+
+.yue ul {
+    list-style-type: square
+}
+
+.yue ol {
+    list-style-type: decimal
+}
+
+.yue li {
+    margin-bottom: .2em
+}
+
+.yue li ol,
+.yue li ul {
+    margin-top: 0;
+    margin-bottom: 0
+}
+
+.yue li ul {
+    list-style-type: disc
+}
+
+.yue li ul ul {
+    list-style-type: circle
+}
+
+.yue li p {
+    margin: .4em 0 .6em
+}
+
+.yue code,
+.yue tt {
+    background-color: rgba(220, 220, 220, .2);
+    color: #f55826;
+    font-size: .96em;
+    padding: 1px 4px;
+    border-radius: 2px;
+    font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
+    word-wrap: break-word
+}
+
+.yue pre {
+    margin: 1.4em 0;
+    padding: 16px 16px 16px 18px;
+    border: none;
+    border-left: 3px solid rgba(0, 0, 0, .08);
+    overflow: auto;
+    line-height: 1.5;
+    font-size: .98em;
+    font-family: Consolas, "Roboto Mono", Menlo, Monaco, "Courier New", monospace;
+    color: rgba(0, 0, 0, .68);
+    background-color: rgba(0, 0, 0, .02)
+}
+
+.yue pre code,
+.yue pre tt {
+    color: rgba(0, 0, 0, .68);
+    border: none;
+    background: 0 0;
+    padding: 0
+}
+
+.yue table {
+    width: 100%;
+    max-width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    margin-bottom: 1.5em;
+    font-size: .96em;
+    box-sizing: border-box
+}
+
+.yue iframe {
+    display: block;
+    max-width: 100%;
+    margin-bottom: 30px
+}
+
+.yue figure iframe {
+    margin: auto
+}
+
+.yue table pre {
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: 0 0
+}
+
+[lang^=en] .yue h1 {
+    font-weight: 900
+}
+
+.yue table[border] td,
+.yue table[border] th {
+    text-align: left;
+    padding: 6px 8px 6px 10px;
+    border: 1px solid #ddd
+}
+
+.yue table[border] td {
+    vertical-align: top
+}
+
+.yue table[border] tr:nth-child(even) {
+    background-color: rgba(0, 0, 0, .01)
+}
+
+body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font: 400 16px/1.42 Roboto, "Helvetica Neue", Helvetica, sans-serif;
+    color: rgba(0, 0, 0, .68)
+}
+
+img {
+    max-width: 100%;
+    vertical-align: middle
+}
+
+h1,
+h2,
+h3,
+strong {
+    color: rgba(0, 0, 0, .9)
+}
+
+a {
+    color: rgba(0, 0, 0, .86);
+    text-decoration: none
+}
+
+.guide-links:after,
+.inner:after,
+.section:after {
+    display: table;
+    content: '';
+    clear: both
+}
+
+.sidebar {
+    position: fixed;
+    z-index: 10;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background: #f9f9f9;
+    border-right: 1px solid #efefef;
+    overflow-x: hidden;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: none
+}
+
+.sidebar .inner {
+    width: 260px;
+    padding: 20px 40px 40px
+}
+
+.sidebar a {
+    text-decoration: none;
+    color: #343;
+    border-bottom: 1px solid transparent
+}
+
+.sidebar a:hover {
+    border-color: rgba(0, 0, 0, .1)
+}
+
+.sidebar h3 {
+    margin: 1em 0 .2em;
+    letter-spacing: -.06em;
+    color: #252b31;
+    font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Droid Sans Fallback", "Microsoft YaHei", sans-serif
+}
+
+.sidebar h1>a,
+.sidebar h2>a,
+.sidebar h3>a {
+    border-bottom-width: 0
+}
+
+.sidebar ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0
+}
+
+.sidebar li {
+    margin-top: 4px
+}
+
+.sidebar li>ul {
+    padding-left: 1em
+}
+
+.sidebar li>a {
+    text-decoration: none;
+    border-bottom-width: 2px
+}
+
+.mobile-close {
+    display: none;
+    position: absolute;
+    right: 10px;
+    top: 10px
+}
+
+.content {
+    margin-left: 340px;
+    padding: 20px 80px 0;
+    overflow: hidden
+}
+
+.content>footer {
+    font-size: .86em;
+    color: #999;
+    padding: 20px 0
+}
+
+.content>footer:before {
+    display: block;
+    margin-bottom: 1em;
+    content: '';
+    width: 100px;
+    border-top: 4px solid rgba(0, 0, 0, .1)
+}
+
+.content>footer a {
+    color: #666;
+    text-decoration: underline
+}
+
+.head {
+    display: none
+}
+
+.globaltoc {
+    margin: 20px 0
+}
+
+.globaltoc>p.caption {
+    display: none
+}
+
+.guide-links {
+    margin-top: 1em;
+    font-family: "Source Sans Pro", "Helvetica Neue", Arial, sans-serif
+}
+
+.guide-links a {
+    border: 0;
+    font-weight: 500
+}
+
+@media (max-width:960px) {
+    .sidebar {
+        transform: translate3d(-341px, 0, 0);
+        transition: transform .2s ease
+    }
+    .expand .sidebar {
+        transform: translate3d(0, 0, 0);
+        max-width: 100%
+    }
+    .expand .mobile-close {
+        display: block
+    }
+    .content {
+        padding: 64px 20px 0;
+        max-width: 840px;
+        margin: 0 auto;
+        box-sizing: border-box
+    }
+    .head {
+        display: block;
+        position: fixed;
+        width: 100%;
+        padding: 1em 20px;
+        box-sizing: border-box;
+        text-align: center;
+        border-bottom: 1px solid #efefef;
+        background: #fff;
+        z-index: 9
+    }
+    .head_menu {
+        position: absolute;
+        top: 1em;
+        left: 2em
+    }
+    .head_menu svg,
+    .mobile-close svg {
+        width: 30px;
+        fill: #ccc
+    }
+    .head_logo {
+        font-weight: 600
+    }
+    .head_logo img {
+        vertical-align: middle;
+        margin-right: 6px;
+        width: 30px;
+        height: 30px
+    }
+}
+
+.rst-other-versions input[name="q"],
+body[data-page=search] input[name="q"] {
+    border: 2px solid rgba(0, 0, 0, .86);
+    padding: 0 10px;
+    line-height: 38px;
+    outline: 0;
+    box-sizing: border-box
+}
+
+body[data-page=search] input[type=submit] {
+    line-height: 42px
+}
+
+#typlog-footnote-mask {
+    display: none;
+    -webkit-tap-highlight-color: transparent
+}
+
+#typlog-footnote-mask.Active {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9
+}
+
+#typlog-footnote-content,
+#typlog-footnote-content a[href^="#fnref"] {
+    display: none
+}
+
+#typlog-footnote-content.Active {
+    display: block;
+    font-size: .86em;
+    color: rgba(0, 0, 0, .68);
+    position: absolute;
+    z-index: 10;
+    width: 100%;
+    max-width: 560px;
+    margin-top: 20px;
+    background: #fff;
+    padding: 20px;
+    box-sizing: border-box;
+    box-shadow: 0 0 10px 1px rgba(0, 0, 0, .16)
+}
+
+@media (min-width:560px) {
+    #typlog-footnote-content.Active {
+        border-radius: 3px
+    }
+}
+
+.highlight {
+    color: #586e75
+}
+
+.highlight .hll {
+    font-weight: 700
+}
+
+.highlight .c {
+    color: #93a1a1
+}
+
+.highlight .err {
+    color: #586e75
+}
+
+.highlight .g {
+    color: #586e75
+}
+
+.highlight .k {
+    color: #859900
+}
+
+.highlight .l {
+    color: #586e75
+}
+
+.highlight .n {
+    color: #586e75
+}
+
+.highlight .o {
+    color: #859900
+}
+
+.highlight .x {
+    color: #cb4b16
+}
+
+.highlight .p {
+    color: #586e75
+}
+
+.highlight .cm {
+    color: #93a1a1
+}
+
+.highlight .cp {
+    color: #859900
+}
+
+.highlight .c1 {
+    color: #93a1a1
+}
+
+.highlight .cs {
+    color: #859900
+}
+
+.highlight .gd {
+    color: #2aa198
+}
+
+.highlight .ge {
+    color: #586e75;
+    font-style: italic
+}
+
+.highlight .gr {
+    color: #dc322f
+}
+
+.highlight .gh {
+    color: #cb4b16
+}
+
+.highlight .gi {
+    color: #859900
+}
+
+.highlight .go {
+    color: #586e75
+}
+
+.highlight .gp {
+    color: #586e75
+}
+
+.highlight .gs {
+    color: #586e75;
+    font-weight: 700
+}
+
+.highlight .gu {
+    color: #cb4b16
+}
+
+.highlight .gt {
+    color: #586e75
+}
+
+.highlight .kc {
+    color: #cb4b16
+}
+
+.highlight .kd {
+    color: #268bd2
+}
+
+.highlight .kn {
+    color: #859900
+}
+
+.highlight .kp {
+    color: #859900
+}
+
+.highlight .kr {
+    color: #268bd2
+}
+
+.highlight .kt {
+    color: #dc322f
+}
+
+.highlight .ld {
+    color: #586e75
+}
+
+.highlight .m {
+    color: #2aa198
+}
+
+.highlight .s {
+    color: #2aa198
+}
+
+.highlight .na {
+    color: #586e75
+}
+
+.highlight .nb {
+    color: #b58900
+}
+
+.highlight .nc {
+    color: #268bd2
+}
+
+.highlight .no {
+    color: #cb4b16
+}
+
+.highlight .nd {
+    color: #268bd2
+}
+
+.highlight .ni {
+    color: #cb4b16
+}
+
+.highlight .ne {
+    color: #cb4b16
+}
+
+.highlight .nf {
+    color: #268bd2
+}
+
+.highlight .nl {
+    color: #586e75
+}
+
+.highlight .nn {
+    color: #586e75
+}
+
+.highlight .nx {
+    color: #586e75
+}
+
+.highlight .py {
+    color: #586e75
+}
+
+.highlight .nt {
+    color: #268bd2
+}
+
+.highlight .nv {
+    color: #268bd2
+}
+
+.highlight .ow {
+    color: #859900
+}
+
+.highlight .w {
+    color: #586e75
+}
+
+.highlight .mf {
+    color: #2aa198
+}
+
+.highlight .mh {
+    color: #2aa198
+}
+
+.highlight .mi {
+    color: #2aa198
+}
+
+.highlight .mo {
+    color: #2aa198
+}
+
+.highlight .sb {
+    color: #93a1a1
+}
+
+.highlight .sc {
+    color: #2aa198
+}
+
+.highlight .sd {
+    color: #586e75
+}
+
+.highlight .s2 {
+    color: #2aa198
+}
+
+.highlight .se {
+    color: #cb4b16
+}
+
+.highlight .sh {
+    color: #586e75
+}
+
+.highlight .si {
+    color: #2aa198
+}
+
+.highlight .sx {
+    color: #2aa198
+}
+
+.highlight .sr {
+    color: #dc322f
+}
+
+.highlight .s1 {
+    color: #2aa198
+}
+
+.highlight .ss {
+    color: #2aa198
+}
+
+.highlight .bp {
+    color: #268bd2
+}
+
+.highlight .vc {
+    color: #268bd2
+}
+
+.highlight .vg {
+    color: #268bd2
+}
+
+.highlight .vi {
+    color: #268bd2
+}
+
+.highlight .il {
+    color: #2aa198
+}
+
+a.toc-backref {
+    border: 0
+}
+
+a.headerlink {
+    margin-left: 1px;
+    color: rgba(0, 0, 0, .24);
+    text-decoration: none;
+    visibility: hidden;
+    border-width: 0
+}
+
+a.headerlink:hover {
+    background-color: rgba(0, 0, 0, .02)
+}
+
+caption:hover>a.headerlink,
+div.code-block-caption:hover>a.headerlink,
+dt:hover>a.headerlink,
+h1:hover>a.headerlink,
+h2:hover>a.headerlink,
+h3:hover>a.headerlink,
+h4:hover>a.headerlink,
+h5:hover>a.headerlink,
+h6:hover>a.headerlink,
+p.caption:hover>a.headerlink {
+    visibility: visible
+}
+
+a>.std-ref {
+    font-weight: 700
+}
+
+.contents {
+    display: inline-block;
+    padding: 16px 40px 16px 0;
+    background: #f9f9f9;
+    min-width: 240px;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 5px
+}
+
+.contents .topic-title {
+    color: rgba(0, 0, 0, .4);
+    padding-left: 16px;
+    margin-bottom: 10px;
+    text-transform: uppercase
+}
+
+.contents li>ul,
+.contents li>ul ul,
+.contents ul {
+    list-style-type: none
+}
+
+.contents ul {
+    margin: 0
+}
+
+.contents li {
+    margin-top: 4px
+}
+
+.contents a {
+    border-bottom: 0;
+    color: rgba(0, 0, 0, .5)
+}
+
+.admonition {
+    position: relative;
+    padding: 40px 24px 18px 24px;
+    margin: 2em 0;
+    border-left: 4px solid #ddd;
+    background-color: #f8f8f8
+}
+
+.admonition:before {
+    position: absolute;
+    content: '#';
+    top: 14px;
+    left: -12px;
+    color: #fff;
+    width: 20px;
+    height: 20px;
+    border-radius: 100%;
+    background-color: #ddd;
+    text-align: center;
+    font: normal bold 14px/20px "Helvetica Neue", Arial, sans-serif
+}
+
+.admonition.tip:before {
+    content: 'T';
+    font-size: 12px
+}
+
+.admonition>.admonition-title {
+    position: absolute;
+    margin: 0;
+    top: 12px;
+    left: 24px;
+    font-size: .8em;
+    color: rgba(0, 0, 0, .4);
+    text-transform: uppercase
+}
+
+.admonition>.last {
+    margin-bottom: 0
+}
+
+.admonition.attention,
+.admonition.note {
+    border-color: #03a9f4;
+    background-color: rgba(3, 172, 244, .08)
+}
+
+.admonition.attention:before,
+.admonition.note:before {
+    background-color: #03a9f4
+}
+
+.admonition.attention:before {
+    content: '!'
+}
+
+.admonition.attention>.admonition-title,
+.admonition.note>.admonition-title {
+    font-weight: 700;
+    color: #03a9f4
+}
+
+.admonition.caution,
+.admonition.warning {
+    border-color: #f7ba2a;
+    background-color: rgba(247, 186, 42, .1)
+}
+
+.admonition.caution:before,
+.admonition.warning:before {
+    content: '!';
+    background-color: #f7ba2a
+}
+
+.admonition.caution>.admonition-title,
+.admonition.warning>.admonition-title {
+    font-weight: 700;
+    color: #f1b52a
+}
+
+.admonition.danger,
+.admonition.error {
+    border-color: #ff612f;
+    background-color: rgba(255, 92, 47, .08)
+}
+
+.admonition.danger:before,
+.admonition.error:before {
+    content: '!';
+    background-color: #ff612f
+}
+
+.admonition.danger>.admonition-title,
+.admonition.error>.admonition-title {
+    font-weight: 700;
+    color: #ff612f
+}
+
+.admonition.important {
+    border-color: #b37feb;
+    background-color: rgba(179, 127, 235, .1)
+}
+
+.admonition.important:before {
+    background-color: #b37feb
+}
+
+.admonition.important>.admonition-title {
+    font-weight: 700;
+    color: #b37feb
+}
+
+.admonition.hint {
+    border-color: #36cfc9;
+    background-color: rgba(8, 151, 156, .1)
+}
+
+.admonition.hint:before {
+    background-color: #36cfc9
+}
+
+.admonition.hint>.admonition-title {
+    font-weight: 700;
+    color: #36cfc9
+}
+
+.admonition.tip {
+    border-color: #f759ab;
+    background-color: rgba(247, 89, 171, .1)
+}
+
+.admonition.tip:before {
+    background-color: #f759ab
+}
+
+.admonition.tip>.admonition-title {
+    font-weight: 700;
+    color: #f759ab
+}
+
+.versionmodified {
+    color: rgba(0, 0, 0, .86);
+    font-weight: 700
+}
+
+.deprecated,
+.versionadded,
+.versionchanged {
+    position: relative;
+    padding: 8px 24px;
+    margin: 1em 0;
+    border-left: 4px solid transparent
+}
+
+.deprecated:before,
+.versionadded:before,
+.versionchanged:before {
+    position: absolute;
+    content: '!';
+    top: 8px;
+    left: -12px;
+    color: #fff;
+    width: 20px;
+    height: 20px;
+    border-radius: 100%;
+    text-align: center;
+    font: normal bold 14px/20px "Helvetica Neue", Arial, sans-serif
+}
+
+.versionadded {
+    border-color: #49c784;
+    background-color: rgba(73, 199, 132, .08)
+}
+
+.versionadded:before {
+    content: '#';
+    background-color: #49c784
+}
+
+.versionchanged {
+    border-color: #f7ba2a;
+    background-color: rgba(247, 186, 42, .08)
+}
+
+.versionchanged:before {
+    background-color: #f7ba2a
+}
+
+.deprecated {
+    border-color: #ff612f;
+    background-color: rgba(255, 92, 47, .08)
+}
+
+.deprecated:before {
+    background-color: #ff612f
+}
+
+.deprecated>p,
+.versionadded>p,
+.versionchanged>p {
+    margin: 0
+}
+
+.yue table.footnote {
+    display: none
+}
+
+a.footnote-reference {
+    display: inline-block;
+    padding: 0 4px;
+    text-align: center;
+    font-weight: 700;
+    font-size: 8px;
+    line-height: 14px;
+    border-bottom: 0;
+    background-color: rgba(0, 0, 0, .18);
+    color: #fff;
+    border-radius: 3px;
+    vertical-align: top;
+    transition: all .1s ease
+}
+
+.body a.footnote-reference:hover {
+    color: #fff;
+    background-color: rgba(0, 0, 0, .8)
+}
+
+.yue table.citation {
+    margin-bottom: 10px
+}
+
+table.docutils td.label {
+    width: 1px;
+    padding-right: .6em
+}
+
+.button {
+    display: inline-block;
+    padding: 1.2em 2em;
+    font-weight: 700;
+    letter-spacing: .25rem;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: #fff;
+    background-color: rgba(0, 0, 0, .98);
+    border: 0;
+    transition: background-color .1s
+}
+
+.input-group {
+    display: flex;
+    border: 2px solid rgba(0, 0, 0, .86)
+}
+
+.input-group>input[type=text] {
+    flex-grow: 1;
+    outline: 0;
+    border: 0;
+    padding: .6em 10px
+}
+
+.input-group>button,
+body[data-page=search] input[type=submit] {
+    display: inline-block;
+    padding: 0 .8em;
+    font-weight: 700;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: #fff;
+    background-color: rgba(0, 0, 0, .86);
+    border: 0;
+    transition: background-color .1s;
+    cursor: pointer;
+    border-radius: 0;
+    outline: 0
+}
+
+.highlighted {
+    padding: 1px 4px;
+    opacity: .6;
+    color: #fff;
+    background-color: rgba(0, 0, 0, .68)
+}
+
+.highlight,
+.literal-block-wrapper {
+    margin: 1.4em 0
+}
+
+.highlight pre,
+.highlighttable .highlight,
+.literal-block-wrapper .highlight {
+    margin: 0
+}
+
+.code-block-caption {
+    color: rgba(0, 0, 0, .3)
+}
+
+.highlighttable {
+    background: rgba(0, 0, 0, .02)
+}
+
+.highlighttable .linenos {
+    width: 1px
+}
+
+.highlighttable .linenodiv {
+    padding: 10px 6px;
+    background: rgba(0, 0, 0, .03);
+    text-align: right
+}
+
+.highlighttable .linenodiv pre {
+    color: rgba(0, 0, 0, .3)
+}
+
+.highlighttable .highlight {
+    padding-left: 10px
+}
+
+.hlist td {
+    vertical-align: top
+}
+
+p.centered {
+    text-align: center
+}
+
+.float-left {
+    float: left
+}
+
+.float-right {
+    float: right
+}
+
+.project_description {
+    margin: 1em 0;
+    color: rgba(0, 0, 0, .6)
+}
+
+a.logo {
+    display: block;
+    font-size: 1.2em;
+    font-weight: 900;
+    letter-spacing: 1px;
+    text-decoration: none;
+    margin-bottom: 1em;
+    border: 0
+}
+
+.logo img {
+    vertical-align: middle;
+    margin-right: 6px;
+    width: 40px;
+    height: 40px
+}
+
+.github_wrap {
+    margin: 1em 0
+}
+
+.github_wrap .github {
+    display: inline-block;
+    border: 1px solid #d5d5d5;
+    background-image: linear-gradient(to bottom, #fcfcfc 0, #eee 100%);
+    padding: 6px 14px;
+    border-radius: 5px
+}
+
+.github>span {
+    display: inline-block;
+    text-align: center;
+    vertical-align: middle;
+    line-height: 1;
+    font-size: 14px;
+    color: rgba(0, 0, 0, .5)
+}
+
+.github_icon {
+    width: 30px;
+    height: 30px;
+    background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjQwcHgiIGhlaWdodD0iNDBweCIgdmlld0JveD0iMTIgMTIgNDAgNDAiIGVuYWJsZS1iYWNrZ3JvdW5kPSJuZXcgMTIgMTIgNDAgNDAiIHhtbDpzcGFjZT0icHJlc2VydmUiPjxwYXRoIGZpbGw9IiMzMzMzMzMiIGQ9Ik0zMiAxMy40Yy0xMC41IDAtMTkgOC41LTE5IDE5YzAgOC40IDUuNSAxNS41IDEzIDE4YzEgMC4yIDEuMy0wLjQgMS4zLTAuOWMwLTAuNSAwLTEuNyAwLTMuMiBjLTUuMyAxLjEtNi40LTIuNi02LjQtMi42QzIwIDQxLjYgMTguOCA0MSAxOC44IDQxYy0xLjctMS4yIDAuMS0xLjEgMC4xLTEuMWMxLjkgMC4xIDIuOSAyIDIuOSAyYzEuNyAyLjkgNC41IDIuMSA1LjUgMS42IGMwLjItMS4yIDAuNy0yLjEgMS4yLTIuNmMtNC4yLTAuNS04LjctMi4xLTguNy05LjRjMC0yLjEgMC43LTMuNyAyLTUuMWMtMC4yLTAuNS0wLjgtMi40IDAuMi01YzAgMCAxLjYtMC41IDUuMiAyIGMxLjUtMC40IDMuMS0wLjcgNC44LTAuN2MxLjYgMCAzLjMgMC4yIDQuNyAwLjdjMy42LTIuNCA1LjItMiA1LjItMmMxIDIuNiAwLjQgNC42IDAuMiA1YzEuMiAxLjMgMiAzIDIgNS4xYzAgNy4zLTQuNSA4LjktOC43IDkuNCBjMC43IDAuNiAxLjMgMS43IDEuMyAzLjVjMCAyLjYgMCA0LjYgMCA1LjJjMCAwLjUgMC40IDEuMSAxLjMgMC45YzcuNS0yLjYgMTMtOS43IDEzLTE4LjFDNTEgMjEuOSA0Mi41IDEzLjQgMzIgMTMuNHoiLz48L3N2Zz4=);
+    background-size: 100% 100%;
+    background-repeat: no-repeat
+}
+
+.github span>strong {
+    display: block;
+    font-size: 16px
+}
+
+.github_stars {
+    position: relative;
+    margin: 0 20px 0 10px
+}
+
+.github_stars:after {
+    content: '';
+    display: block;
+    border-right: 1px solid rgba(0, 0, 0, .2);
+    height: 12px;
+    position: absolute;
+    right: -14px;
+    top: 10px
+}
+
+.sponsors {
+    margin: 15px 0
+}
+
+.sponsor {
+    background: rgba(0, 0, 0, .05);
+    padding: 15px;
+    margin: 5px 0;
+    border-radius: 4px
+}
+
+.sponsor:after {
+    content: '';
+    display: table;
+    clear: both
+}
+
+.sponsor img {
+    width: 48px;
+    vertical-align: middle
+}
+
+.sponsor a.sponsor_image {
+    float: left;
+    border-bottom: none
+}
+
+.sponsor_text {
+    overflow: hidden;
+    padding-left: 10px;
+    vertical-align: middle;
+    max-width: calc(100% - 60px)
+}
+
+.content .sponsor,
+.content .sponsor_text {
+    display: inline-block
+}
+
+.content .sponsor img {
+    width: auto;
+    height: 40px
+}
+
+.content a.sponsor_image {
+    display: inline-block;
+    float: none
+}
+
+.badge {
+    display: inline-block;
+    padding: 3px 6px;
+    min-width: 3em;
+    text-align: center;
+    vertical-align: middle;
+    background-color: #999;
+    color: #fff;
+    line-height: 1;
+    border-radius: 2px;
+    font-size: 13px;
+    opacity: .98;
+    margin-right: 4px;
+    font-family: Consolas, Menlo, Monaco, "Courier New", monospace;
+    user-select: none
+}
+
+.badge-one {
+    font-size: 12px;
+    min-width: 0;
+    padding: 4px 6px
+}
+
+.badge-todo,
+.badge-yellow {
+    background-color: #f7ba2a
+}
+
+.badge-done,
+.badge-green {
+    background-color: #49c784
+}
+
+.badge-blue,
+.badge-doing,
+.badge-plan {
+    background-color: #03a9f4
+}
+
+.badge-red {
+    background-color: #ff612f
+}
+
+code.descclassname {
+    padding: 0;
+    background-color: transparent
+}
+
+code.descname {
+    font-weight: 700;
+    padding: 0;
+    background-color: transparent
+}
+
+dd {
+    margin: 4px 0 10px 2em
+}
+
+dd>table.field-list .field-name {
+    display: block;
+    font-size: .86em;
+    color: rgba(245, 88, 38, .8);
+    padding: 0;
+    text-align: left;
+    text-transform: uppercase
+}
+
+dd>table.field-list .field-body {
+    display: block;
+    padding: 0 0 0 1em
+}
+
+.yue dd>p {
+    margin-bottom: .86em
+}
+
+dl.class dt,
+dl.data dt,
+dl.exception dt,
+dl.function dt,
+dl.method dt {
+    padding: 5px;
+    color: rgba(0, 0, 0, .4);
+    border-top: 2px solid rgba(245, 88, 38, .4);
+    background: rgba(245, 88, 38, .05)
+}
+
+dl.class dt>em,
+dl.data dt>em,
+dl.exception dt>em,
+dl.function dt>em,
+dl.method dt>em {
+    font-size: .98em;
+    color: rgba(0, 0, 0, .68)
+}
+
+.injected .rst-versions.rst-badge {
+    left: 0;
+    bottom: 0;
+    width: 340px;
+    max-width: 100%;
+    color: rgba(0, 0, 0, .68);
+    background-color: #f7f7f7
+}
+
+.injected .rst-versions.rst-badge .rst-current-version {
+    text-align: right;
+    background-color: #eee
+}
+
+.injected .rst-versions.rst-badge .fa-book {
+    float: left
+}
+
+.injected .rst-versions .rst-current-version .fa,
+.injected .rst-versions .rst-other-versions dd a {
+    color: rgba(0, 0, 0, .68)
+}
+
+.injected .rst-versions .rst-other-versions hr {
+    border-color: #ddd
+}
+
+@media (max-width:960px) {
+    .injected .rst-versions {
+        transform: translate3d(-340px, 0, 0);
+        transition: transform .2s ease
+    }
+    .expand .injected .rst-versions {
+        transform: translate3d(0, 0, 0)
+    }
+}

--- a/sphinx_typlog_theme/static/typlog.css
+++ b/sphinx_typlog_theme/static/typlog.css
@@ -18,6 +18,13 @@ section {
     display: block
 }
 
+:target::before {
+    content: "";
+    display: block;
+    height: 60px;
+    margin: -60px 0 0;
+}
+
 h1 {
     font-size: 2em;
     margin: .67em 0


### PR DESCRIPTION
修改内容：

-  原主题在移动页面锚点跳转后锚点标题会被headers覆盖看不见，现在只在跳转的锚点上增加1行下移整块保证不被覆盖。参考了：https://stackoverflow.com/a/28824157
- 原主题正常来说，大标题间距2行，子标题间距1行。但子标题间如果以列表或note等提示框结尾，间距会从1行变成2行，就不统一了。把间距统一改成1行。
- 原主题行块无间距，如果用来写大段文字，会全凑在一起，加了1空行间距。（不是‘上边距'，写错了...）
- 搜索框的文字改成只用’Search'后，启用本地化后sphinx能自动翻译，zh_CN下会翻译成搜索。