### PR TITLE
Make search placeholder configurable

### DIFF
--- a/sphinx_typlog_theme/searchbox.html
+++ b/sphinx_typlog_theme/searchbox.html
@@ -2,7 +2,7 @@
 <div id="searchbox">
   <form class="search" action="{{ pathto('search') }}" method="get">
     <div class="input-group">
-      <input type="text" name="q" placeholder="{{ _('Enter search terms or a module, class or function name.') }}" />
+      <input type="text" name="q" placeholder="{{ _(theme_search_placeholder) }}" />
       <button type="submit">{{ _('Go') }}</button>
     </div>
     <input type="hidden" name="check_keywords" value="yes" />

--- a/sphinx_typlog_theme/theme.conf
+++ b/sphinx_typlog_theme/theme.conf
@@ -16,3 +16,4 @@ twitter =
 og_image =
 meta_html =
 webfont = true
+search_placeholder = Enter search terms or a module, class or function name.


### PR DESCRIPTION
Makes the search placeholder configurable.

The current placeholder is quite long and overflows.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/2379650/50431574-7a800080-0891-11e9-9d2d-724d12b52f26.png">

This change allows me to customize it to a shorter placeholder.


```python
html_theme_options = {
    # ...
    'search_placeholder': 'Search',
}
```

<img width="300" alt="image" src="https://user-images.githubusercontent.com/2379650/50431597-a7341800-0891-11e9-8809-d0050b9bd603.png">

