### PR TITLE
let footer configurable

### DIFF
--- a/sphinx_typlog_theme/footer.html
+++ b/sphinx_typlog_theme/footer.html
@@ -1,0 +1,16 @@
+{%- block footer %}
+<footer class="t-foot">
+    {%- block extrafooter %} {% endblock %}
+    {%- if show_copyright %}
+    {%- if hasdoc('copyright') %}
+    {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright
+    }}.{% endtrans %}
+    {%- else %}
+    {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
+    {%- endif %}
+    <br>
+    {%- endif %}
+    A <a href="https://typlog.com/">typlog</a> <a href="https://github.com/typlog/sphinx-typlog-theme">sphinx theme</a>,
+    designed by <a href="https://lepture.com/">Hsiaoming Yang</a>.
+</footer>
+{%- endblock %}

--- a/sphinx_typlog_theme/layout.html
+++ b/sphinx_typlog_theme/layout.html
@@ -94,20 +94,7 @@
   </aside>
   <div class="t-content">
     <div class="t-body yue">{% block body %}{% endblock %}</div>
-    {%- block footer %}
-    <footer class="t-foot">
-      {%- if show_copyright %}
-        {%- if hasdoc('copyright') %}
-          {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}
-        {%- else %}
-          {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}
-        {%- endif %}
-        <br>
-      {%- endif %}
-      A <a href="https://typlog.com/">typlog</a> <a href="https://github.com/typlog/sphinx-typlog-theme">sphinx theme</a>,
-      designed by <a href="https://lepture.com/">Hsiaoming Yang</a>.
-    </footer>
-    {%- endblock %}
+    {%- include "footer.html" %}
   </div>
   <script>{% include "js/app.js" %}</script>
 </body>


### PR DESCRIPTION
Separate footer from the layout.html and add `{%- block extrafooter %} {% endblock %}`  let user can add something like comment templates.
For example, then we can add `footer.html` in sphinx project templates folder
(../source/.templates(or _templates)/footer.html)
and add code like(my project use it):
```
{% extends "!footer.html" %}
{%- block extrafooter %}
<!-- 来必力City版安装代码 -->
<div id="lv-container" data-id="city" data-uid="xxxxxxxxxxxxxx">
    <script type="text/javascript">
        (function (d, s) {
            var j, e = d.getElementsByTagName(s)[0];

            if (typeof LivereTower === 'function') { return; }

            j = d.createElement(s);
            j.src = 'https://cdn-city.livere.com/js/embed.dist.js';
            j.async = true;

            e.parentNode.insertBefore(j, e);
        })(document, 'script');
    </script>
    <noscript> 为正常使用来必力评论功能请激活JavaScript</noscript>
</div>
{%- endblock %}
```
then in footer people can comment(power by livere).

picture:
![image](https://user-images.githubusercontent.com/29814851/50452703-9c9f7e80-0976-11e9-93be-6dda92cd7dda.png)
